### PR TITLE
fix in reading from io

### DIFF
--- a/net/slice_reader.go
+++ b/net/slice_reader.go
@@ -50,7 +50,7 @@ func (sl *SliceReader) Read(n int) (res []byte, err error) {
 }
 
 func (sl *SliceReader) ReadByte() (res byte, err error) {
-	if len(sl.buf) > 1 {
+	if len(sl.buf) > 0 {
 		res = sl.buf[0]
 		sl.buf = sl.buf[1:]
 		return


### PR DESCRIPTION
This is bugfix 

how to repeat bug:
I make request to server, server give me answer with only 1 byte return code (as expected). But  iproto library wait until next request happen and read some new data. As result - timeout