### PR TITLE
some bigfix, crush/race

### DIFF
--- a/marshal/writer.go
+++ b/marshal/writer.go
@@ -225,7 +225,9 @@ func (w *Writer) Uint8slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]uint8)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]uint8)(unsafe.Pointer(sh))
 			w.Uint8sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {
@@ -239,7 +241,9 @@ func (w *Writer) Int8slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]uint8)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]uint8)(unsafe.Pointer(sh))
 			w.Uint8sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {

--- a/marshal/writer_any.go
+++ b/marshal/writer_any.go
@@ -122,7 +122,9 @@ func (w *Writer) Uint16slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]uint16)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]uint16)(unsafe.Pointer(sh))
 			w.Uint16sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {
@@ -136,7 +138,9 @@ func (w *Writer) Uint32slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]uint32)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]uint32)(unsafe.Pointer(sh))
 			w.Uint32sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {
@@ -150,7 +154,9 @@ func (w *Writer) Uint64slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]uint64)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]uint64)(unsafe.Pointer(sh))
 			w.Uint64sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {
@@ -164,7 +170,9 @@ func (w *Writer) Int16slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]int16)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]int16)(unsafe.Pointer(sh))
 			w.Int16sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {
@@ -178,7 +186,9 @@ func (w *Writer) Int32slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]int32)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]int32)(unsafe.Pointer(sh))
 			w.Int32sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {
@@ -192,7 +202,9 @@ func (w *Writer) Int64slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]int64)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]int64)(unsafe.Pointer(sh))
 			w.Int64sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {
@@ -206,7 +218,9 @@ func (w *Writer) Float32slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]float32)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]float32)(unsafe.Pointer(sh))
 			w.Float32sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {
@@ -220,7 +234,9 @@ func (w *Writer) Float64slVal(v reflect.Value) {
 	l := v.Len()
 	if l > 0 {
 		if v.Index(0).CanAddr() {
-			p := (*[gg]float64)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
+                        _p := uintptr( (unsafe.Pointer(v.Index(0).Addr().Pointer())) )
+                        sh := &reflect.SliceHeader{Data: _p, Len:  l, Cap:  l, }
+                        p := *(*[]float64)(unsafe.Pointer(sh))
 			w.Float64sl(p[:l])
 		} else {
 			for i := 0; i < l; i++ {

--- a/service.go
+++ b/service.go
@@ -134,7 +134,7 @@ func (s *SimplePoint) Send(r *Request) {
 		if r.Performed() {
 			return
 		}
-		log.Panicf("Request already sent somewhere %+v")
+		log.Panicf("Request already sent somewhere %+v", s)
 	}
 
 	r.SetTimeout(s.Timeout)


### PR DESCRIPTION
 1. crush
```
fatal error: checkptr: converted pointer straddles multiple allocations

goroutine 23 [running]:
runtime.throw(0x655eec, 0x3a)
	/usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc0000ab960 sp=0xc0000ab930 pc=0x468452
runtime.checkptrAlignment(0xc000098060, 0x618bc0, 0x1)
	/usr/local/go/src/runtime/checkptr.go:20 +0xc9 fp=0xc0000ab990 sp=0xc0000ab960 pc=0x438769
github.com/funny-falcon/go-iproto/marshal.(*Writer).Uint64slVal(0x78e060, 0x615ee0, 0xc0000a20a8, 0x97)
```
happened, if I try pack any array, there panic in string like 
`                       p := (*[gg]uint8)(unsafe.Pointer(v.Index(0).Addr().Pointer()))
happened when occure  "heckptrBase(p) != checkptrBase(add(p, size-1))", where size  = gg 

2. race in case nonatomic access to variable