### PR TITLE
fix races

### DIFF
--- a/marshal/reader_reflect.go
+++ b/marshal/reader_reflect.go
@@ -354,9 +354,9 @@ var rsL sync.Mutex
 
 func ReaderFor(rt reflect.Type) (rd *TReader) {
 	rtid := reflect.ValueOf(rt).Pointer()
+	rsL.Lock()
+	defer rsL.Unlock()
 	if rd = rs[rtid]; rd == nil {
-		rsL.Lock()
-		defer rsL.Unlock()
 		if rd = rs[rtid]; rd == nil {
 			rss = make(map[uintptr]*TReader, len(ws)+1)
 			for t, r := range rs {

--- a/marshal/writer_reflect.go
+++ b/marshal/writer_reflect.go
@@ -228,9 +228,9 @@ var wsL sync.Mutex
 
 func WriterFor(rt reflect.Type) (wr *TWriter) {
 	rtid := reflect.ValueOf(rt).Pointer()
+	wsL.Lock()
+	defer wsL.Unlock()
 	if wr = ws[rtid]; wr == nil {
-		wsL.Lock()
-		defer wsL.Unlock()
 		if wr = ws[rtid]; wr == nil {
 			wss = make(map[uintptr]*TWriter, len(ws)+1)
 			for t, w := range ws {

--- a/net/client/connection/connection.go
+++ b/net/client/connection/connection.go
@@ -289,11 +289,18 @@ Loop:
 			if !request.SetInFly(req) {
 				continue
 			}
+			request.Lock()
+			if !request.IsInFly() {
+				request.Unlock()
+				continue
+			}
 			requestHeader = nt.Request{
 				Msg:  request.Msg,
 				Id:   req.fakeId,
 				Body: request.Body,
 			}
+			request.Unlock()
+
 			req = nil
 
 			err = w.WriteRequest(requestHeader)

--- a/net/client/connection/request_holder.go
+++ b/net/client/connection/request_holder.go
@@ -91,8 +91,11 @@ func (h *RequestHolder) remove(fakeId uint32) (ireq *iproto.Request) {
 	}
 
 	req := &reqs.reqs[fakeId&rowMask]
+	req.Lock()
 	req.fakeId = 0
 	ireq = req.Request
+	req.Unlock()
+
 	h.put++
 	return
 }

--- a/request.go
+++ b/request.go
@@ -97,6 +97,10 @@ func (r *Request) SetInFly(mid RequestBookmark) (set bool) {
 	return
 }
 
+func (r *Request) IsInFly() (set bool) {
+	return atomic.LoadUint32(&r.state) == RsInFly
+}
+
 func (r *Request) Performed() bool {
 	st := atomic.LoadUint32(&r.state)
 	return st == RsPrepared || st == RsPerformed
@@ -122,7 +126,7 @@ func (r *Request) ResetToNew() bool {
 		r.state = RsNew
 		return true
 	}
-	log.Panicf("ResetToPending should be called only for performed requests")
+	log.Panicf("ResetToNew should be called only for performed requests")
 	return false
 }
 

--- a/sbox/reader.go
+++ b/sbox/reader.go
@@ -52,9 +52,9 @@ var rsL sync.Mutex
 
 func reader(rt reflect.Type) (rd *TReader) {
 	rtid := reflect.ValueOf(rt).Pointer()
+	rsL.Lock()
+	defer rsL.Unlock()
 	if rd = rs[rtid]; rd == nil {
-		rsL.Lock()
-		defer rsL.Unlock()
 		if rd = rs[rtid]; rd == nil {
 			rss = make(map[uintptr]*TReader, len(ws)+1)
 			for t, r := range rs {

--- a/sbox/result.go
+++ b/sbox/result.go
@@ -15,7 +15,7 @@ var readerCache unsafe.Pointer = unsafe.Pointer(&[2]marshal.Reader{})
 func ReadFirst(b []byte, v interface{}) (read bool, total int, err error) {
 	var t unsafe.Pointer
 	var r *[2]marshal.Reader
-	if t = readerCache; t != nil {
+	if t = atomic.LoadPointer(&readerCache); t != nil {
 		if atomic.CompareAndSwapPointer(&readerCache, t, nil) {
 			r = (*[2]marshal.Reader)(t)
 			*r = [2]marshal.Reader{{Body: b}, {}}
@@ -42,7 +42,7 @@ Got:
 func ReadMany(b []byte, v interface{}) (read, total int, err error) {
 	var t unsafe.Pointer
 	var r *[2]marshal.Reader
-	if t = readerCache; t != nil {
+	if t = atomic.LoadPointer(&readerCache); t != nil {
 		if atomic.CompareAndSwapPointer(&readerCache, t, nil) {
 			r = (*[2]marshal.Reader)(t)
 			*r = [2]marshal.Reader{{Body: b}, {}}

--- a/sbox/writer.go
+++ b/sbox/writer.go
@@ -82,10 +82,10 @@ var wss = ws
 var wsL sync.Mutex
 
 func writer(rt reflect.Type) (wr *TWriter) {
+	wsL.Lock()
+	defer wsL.Unlock()
 	rtid := reflect.ValueOf(rt).Pointer()
 	if wr = ws[rtid]; wr == nil {
-		wsL.Lock()
-		defer wsL.Unlock()
 		if wr = ws[rtid]; wr == nil {
 			wss = make(map[uintptr]*TWriter, len(ws)+1)
 			for t, w := range ws {

--- a/service.go
+++ b/service.go
@@ -129,6 +129,8 @@ func (s *SimplePoint) Send(r *Request) {
 		log.Panicf("you should not call Send on child endpoint %+v", s)
 	}
 
+	r.Lock()
+	defer r.Unlock()
 	if !r.SetPending() {
 		/* this could happen if SetDeadline already respond with timeout */
 		if r.Performed() {

--- a/wait_group.go
+++ b/wait_group.go
@@ -96,10 +96,17 @@ func (w *MultiRequest) Request(msg RequestType, body interface{}) *Request {
 		}
 		w.m.Unlock()
 	} else {
+		w.m.Lock()
 		w.requests = append(w.requests, req)
+		w.m.Unlock()
 	}
+
+	w.m.Lock()
 	atomic.StoreUint32(&w.r, uint32(len(w.requests)))
-	if atomic.LoadUint32(&w.kind)&mrFailed != 0 {
+	kind := w.kind
+	w.m.Unlock()
+
+	if kind&mrFailed != 0 {
 		w.performFail(req)
 	}
 	return req


### PR DESCRIPTION
here is fixes for following races
1.
```
WARNING: DATA RACE
Write at 0x00c0022ae010 by goroutine 11:
  github.com/funny-falcon/go-iproto.(*Request).chainResponse()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:151 +0x2ee
  github.com/funny-falcon/go-iproto.(*Request).RespondFail()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:176 +0xa8
  github.com/funny-falcon/go-iproto.(*Request).Expire()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:52 +0x44
  github.com/funny-falcon/go-iproto.(*tHeap).loop()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/custom_timer.go:125 +0x2b8

Previous read at 0x00c0022ae010 by goroutine 46:
  github.com/funny-falcon/go-iproto/net/client/connection.(*Connection).writeLoop()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/net/client/connection/connection.go:295 +0x32b
```
2.
```
WARNING: DATA RACE
Read at 0x00c00023659c by goroutine 56:
  github.com/funny-falcon/go-iproto.(*MultiRequest).Respond()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/wait_group.go:179 +0x3c4
  github.com/funny-falcon/go-iproto.(*Request).chainResponse()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:152 +0x294
  github.com/funny-falcon/go-iproto.(*Request).RespondBytes()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:172 +0xb0
  github.com/funny-falcon/go-iproto/net/client/connection.(*Connection).readLoop()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/net/client/connection/connection.go:220 +0x324

Previous write at 0x00c00023659c by goroutine 21:
  sync/atomic.StoreInt32()
      /usr/local/go/src/runtime/race_amd64.s:229 +0xb
  github.com/funny-falcon/go-iproto.(*MultiRequest).Request()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/wait_group.go:104 +0x315
  github.com/funny-falcon/go-iproto.(*MultiRequest).Send()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/wait_group.go:118 +0x71
```
3.
```
WARNING: DATA RACE
Write at 0x00c006a80140 by goroutine 8:
  github.com/funny-falcon/go-iproto.(*Request).chainResponse()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:144 +0x1ca
  github.com/funny-falcon/go-iproto.(*Request).RespondFail()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:180 +0xa8
  github.com/funny-falcon/go-iproto.(*Request).Expire()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:52 +0x44
  github.com/funny-falcon/go-iproto.(*tHeap).loop()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/custom_timer.go:125 +0x2b8

Previous read at 0x00c006a80140 by goroutine 38:
  sync/atomic.LoadInt32()
      /usr/local/go/src/runtime/race_amd64.s:206 +0xb
  github.com/funny-falcon/go-iproto.(*Request).Performed()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/request.go:105 +0xcb
  github.com/funny-falcon/go-iproto.(*SimplePoint).Send()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/service.go:143 +0xe7
  github.com/funny-falcon/go-iproto/net/client.(*Server).Send()
      <autogenerated>:1 +0x51
  github.com/funny-falcon/go-iproto.(*MultiRequest).Send()
      /home/ivanov/go/src/github.com/funny-falcon/go-iproto/wait_group.go:124 +0x94
```

and some other